### PR TITLE
Added test-rpc.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "coveralls": "~3.0.1",
     "js-beautify": "^1.7.5",
     "jscoverage": "~0.6.0",
-    "nodeunit": "^0.11.2"
+    "nodeunit": "^0.11.2",
+    "socket.io-client": "1.4.5"
   },
   "scripts": {
     "start": "node server.js",

--- a/src/server.js
+++ b/src/server.js
@@ -36,6 +36,10 @@ var serverStart = function (port, directory, callback) {
         }
     }
 
+    if (callback) {
+        callback(serverEmitter);
+    }
+
     return (serverEmitter);
 };
 

--- a/test/test-rpc.js
+++ b/test/test-rpc.js
@@ -1,0 +1,25 @@
+var server = require('../src/server');
+var bonescript = require('../src/bonescript');
+var serverEmitter = null;
+
+exports.setUp = function (callback) {
+    server.serverStart(8000, process.cwd(), mycb);
+
+    function mycb(emitter) {
+        serverEmitter = emitter;
+        bonescript.startClient('127.0.0.1', 8000, callback);
+    }
+};
+
+exports.testRPC1 = function (test) {
+    test.expect(1);
+    test.doesNotThrow(function () {
+        console.log(bonescript);
+        var b = bonescript.require('bonescript');
+        b.getPlatform(function (platform) {
+            console.log('Name: ' + platform.name);
+            console.log('Version: ' + platform.bonescript);
+        });
+    });
+    test.done();
+};


### PR DESCRIPTION
Some fixes were made such that bonescript.js can run via node.js. I haven't yet verified that it doesn't break the browser.

An internal startClient function was created.

Added a devDependency on socket.io-client.